### PR TITLE
Clang-tidy updates

### DIFF
--- a/include/os5000/os5000_asio.h
+++ b/include/os5000/os5000_asio.h
@@ -17,9 +17,9 @@ class OS5000Serial
 
   ~OS5000Serial();
 
-  bool connect(const std::string &port, const int baud);
+  bool connect(const std::string &port, int baud);
 
-  void init(const int rate);
+  void init(int rate);
 
   void getValues(float *roll, float *pitch, float *yaw, float *temp);
 

--- a/src/os5000_core.cpp
+++ b/src/os5000_core.cpp
@@ -136,7 +136,7 @@ void OS5000::configCallback(os5000::os5000Config &config, uint32_t level)
 
   // Set class variables to new values.
   baud_ = config.baud;
-  portname_ = config.port.c_str();
+  portname_ = config.port;
   rate_ = config.rate;
   if (!isConnected())
   {


### PR DESCRIPTION
Fixed clang-tidy warnings for redundant c_str() and using const-qualified parameters in function declaration where it has no effect.